### PR TITLE
Serve plugin from localhost; Regenerate OpenAPI spec on route change; Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: run
+run:
+	uvicorn main:app --reload

--- a/main.py
+++ b/main.py
@@ -1,12 +1,39 @@
 import json
 from fastapi import FastAPI, Request, HTTPException, Body
 from fastapi.responses import FileResponse, JSONResponse
+from fastapi.openapi.utils import get_openapi
+from fastapi.middleware.cors import CORSMiddleware
 import trafilatura
 from pathlib import Path
 from requests_html import AsyncHTMLSession
 
+
+################################################
+# CONFIG
+################################################
+
 app = FastAPI()
 
+LOCALHOST_PORT=5002
+
+# Add CORS for openapi domains to enable localhost plugin serving
+origins = [
+    "http://localhost",
+    f"http://localhost:{LOCALHOST_PORT}",
+    "https://chat.openai.com",
+    "https://openai.com",
+]
+app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=['*'],
+        allow_headers=['*'],
+)
+
+################################################
+# ROUTES
+################################################
 
 @app.get("/")
 async def hello_world():
@@ -69,6 +96,24 @@ async def create_file(filepath: str = Body(...), content: str = Body(...)):
         raise HTTPException(status_code=500, detail=f"Error creating file: {e}")
 
 
+################################################
+# BOILERPLATE
+################################################
+
+# Regenerate OpenAPI YAML when this file changes
+def generate_openapi_spec():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title="Code Assistant",
+        version="1.0",
+        description="get url contents or a local file to help you with code",
+        routes=app.routes,
+    )
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
 @app.get("/logo.png")
 async def plugin_logo():
     return FileResponse("logo.png")
@@ -81,8 +126,17 @@ async def plugin_manifest(request: Request):
         text = f.read().replace("PLUGIN_HOSTNAME", f"https://{host}")
     return JSONResponse(content=json.loads(text))
 
+@app.get("/openapi.json")
+async def openapi_spec(request: Request):
+    host = request.headers['host']
+    with open("openapi.json") as f:
+        text = f.read().replace("PLUGIN_HOSTNAME", f"https://{host}")
+    return JSONResponse(content=text, media_type="text/json")
+
+
 
 if __name__ == "__main__":
     import uvicorn
+    app.openapi = generate_openapi_spec
 
-    uvicorn.run(app, host="0.0.0.0", port=5002)
+    uvicorn.run("main:app", host="0.0.0.0", port=LOCALHOST_PORT, reload=True)


### PR DESCRIPTION
- Simplify plugin use by setting up CORS to enable serving plugin from localhost.

- Watch for Flask app route changes => regenerate OpenAPI Spec; remove need for manual server restarts

- Add Makefile for easy plugin boot (`make run`)
